### PR TITLE
🎁 style : publishing/sign-in

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>post mobism</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+     <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+     <title>post-mobism</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,29 +1,19 @@
-<<<<<<< HEAD
-import { RouterProvider } from "react-router-dom";
-import router from "./router/router";
-import AuthProvider from "./context/auth.ctx";
-
-function App() {
-  return <AuthProvider>          
-    <RouterProvider router={router} />
-  </AuthProvider>;
-}
-
-export default App;
-=======
 import { RouterProvider } from "react-router-dom"
 import router from "./router/router"
 import AuthProvider from "./context/auth.ctx"
 import GlobalStyles from "./styles/global.style"
+import { ThemeProvider } from "styled-components"
+import theme from "./styles/theme.style"
 
 function App() {
   return (
-    <AuthProvider>
-      <GlobalStyles />
-      <RouterProvider router={router} />
-    </AuthProvider>
+    <ThemeProvider theme={theme}>
+      <AuthProvider>
+        <GlobalStyles />
+        <RouterProvider router={router} />
+      </AuthProvider>
+    </ThemeProvider>
   )
 }
 
 export default App
->>>>>>> main

--- a/src/components/mmz-input.tsx
+++ b/src/components/mmz-input.tsx
@@ -3,18 +3,18 @@ import styled, { css } from "styled-components"
 
 type InputProps = {
   label: string
-  type: "input" | "file"
+  type: string
   error?: string
   usage?: "signForm" | "postForm"
 } & InputHTMLAttributes<HTMLInputElement>
 
-const MMZinput = ({ label, error, type, usage, ...props }: InputProps) => {
+const MMZinput = ({ id, label, error, type, usage, ...props }: InputProps) => {
   return (
-    <Wrapper>
+    <S.Wrapper>
       <label>{label}</label>
-      <Input type={type} usage={usage} {...props} />
-      {error ? <Message>error message</Message> : <Message>access message</Message>}
-    </Wrapper>
+      <S.Input type={type} usage={usage} {...props} />
+      {error ? <S.Message>error message</S.Message> : <S.Message>access message</S.Message>}
+    </S.Wrapper>
   )
 }
 export default MMZinput
@@ -31,15 +31,28 @@ const usageCSS = {
 }
 
 const Wrapper = styled.div`
-  border: 1px solid ${({ theme }) => theme.COLORS.beige[200]};
-  border-radius: 4px;
-  color: ${({ theme }) => theme.COLORS.beige[800]};
+  padding-bottom: 16px;
+  & > label {
+    font-size: ${({ theme }) => theme.FONT_SIZE.small};
+    display: block;
+    color: ${({ theme }) => theme.COLORS.beige[200]};
+    padding-bottom: 8px;
+  }
 `
 
 const Input = styled.input<{ usage?: "signForm" | "postForm" }>`
   ${({ usage }) => (usage ? usageCSS[usage] : "")}
+  border-radius: 4px;
+  color: ${({ theme }) => theme.COLORS.beige[800]};
+  border: 1px solid ${({ theme }) => theme.COLORS.beige[200]};
 `
 
 const Message = styled.p`
   font-size: ${({ theme }) => theme.FONT_SIZE.XSmall};
 `
+
+const S = {
+  Wrapper,
+  Input,
+  Message,
+}

--- a/src/components/mmz-input.tsx
+++ b/src/components/mmz-input.tsx
@@ -35,16 +35,21 @@ const Wrapper = styled.div`
   & > label {
     font-size: ${({ theme }) => theme.FONT_SIZE.small};
     display: block;
-    color: ${({ theme }) => theme.COLORS.beige[200]};
+    color: ${({ theme }) => theme.COLORS.beige[500]};
     padding-bottom: 8px;
   }
 `
 
 const Input = styled.input<{ usage?: "signForm" | "postForm" }>`
   ${({ usage }) => (usage ? usageCSS[usage] : "")}
-  border-radius: 4px;
   color: ${({ theme }) => theme.COLORS.beige[800]};
-  border: 1px solid ${({ theme }) => theme.COLORS.beige[200]};
+  border: 1px solid ${({ theme }) => theme.COLORS.beige[500]};
+  border-radius: 4px;
+  padding-left: 16px;
+  margin-bottom: 14px;
+  &::placeholder {
+    color: ${({ theme }) => theme.COLORS.beige[500]};
+  }
 `
 
 const Message = styled.p`

--- a/src/consts/form.ts
+++ b/src/consts/form.ts
@@ -1,0 +1,14 @@
+export const SignInArr = [
+  {
+    id: "e-mail",
+    label: "ID",
+    type: "text",
+    placeholder: "e-mail",
+  },
+  {
+    id: "password",
+    label: "password",
+    type: "password",
+    placeholder: "must be over 8 letters and should include special characters",
+  },
+]

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -1,0 +1,11 @@
+declare module "*.svg" {
+  import React = require("react")
+
+  export const ReactComponent: React.FC<React.SVGProps<SVGSVGElement>>
+  const src: string
+  export default src
+}
+//React.ImgHTMLAttributes<HTMLImageElement>.src?: string | undefined
+/**
+ *  TS사용 시 SVG 파일을 모듈로 인식하고 이를 React 컴포넌트로 변환하여 사용할 수 있도록 지시하는 코드
+ */

--- a/src/images/Close.svg
+++ b/src/images/Close.svg
@@ -1,0 +1,9 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<rect width="24" height="24" transform="matrix(-1 0 0 1 24 0)" fill="url(#pattern0)"/>
+<defs>
+<pattern id="pattern0" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image0_14_1799" transform="scale(0.0111111)"/>
+</pattern>
+<image id="image0_14_1799" width="90" height="90" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFoAAABaCAYAAAA4qEECAAAACXBIWXMAAAsTAAALEwEAmpwYAAACEklEQVR4nO2cu07DQBBFXQFfTtJSeFv6lBSRXfEfbqh4SDv/MMhgKREPQRLv7NzZeyQ3VGePko0dNtN1hBBCCCGEEEIIIeQb0/7uWsa0lTG9Ltd2/htKqgnBX3e7KxnSg4xJj6889MPT4/1N5xwI/98kXcqi+v8l6UoW1f+/ki5kUf1PlRRnsSH850/iPPT7UyXlILuv+WkO47/cAp0lKZVjXxr5cPWb4rLLPeaFosl8Gzl3u/jxGvo3mNBiGHvVyB+h03Np525+26wmPJbfRtbbLo6d020p38LifZHYSK42b8Vx/W0EwRF+IerYLcyC1KHTKnhamDpyKYKHBaoDBxNqLlRbiVxzwdpa5BoL11YjWwbQ1iNbhFBGtnkEzsiP1aUo8eqT1rcLtNg5UmSvsXPEyN5ih47sJXYTkWvHbipyrdhNRraO3XRkq9iMbBCbkb/A0AYotw78yMItpOPtnQXKB5a4kaWlbUT5pVI7kSXyK1udRQ4Z22tkiRSb/5w1gMcNDOABGgN4JMwAHnI0gMd2DfBwFk4dOBTF0wLVkcuqeFyYOnS6CM8LUsdu4RaiAI5hfvY7AbkWmdchhuIlYkPN6xDoMRJA8zoy9GAUkHkdGXzUD8S8jszhVcHGmUXxhxjQF8UfYuRkFH+IIapR/CHGAkfx/xx0Pd/69S/LtUH62e8E7k8IIYQQQgghhBDSGfIOZsyJrAVGNhYAAAAASUVORK5CYII="/>
+</defs>
+</svg>

--- a/src/index.css
+++ b/src/index.css
@@ -6,14 +6,11 @@
 }
 
 :root {
-  font-family: 'NotoSans-Condensed','S-CoreDream-3Light', system-ui, sans-serif;
+  font-family: "Roboto Condensed", sans-serif, system-ui, sans-serif;
   line-height: 1.5;
-  font-weight: 400;
-
+  font-weight: 300;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
 }
 
 body {

--- a/src/pages/detail/detail.index.tsx
+++ b/src/pages/detail/detail.index.tsx
@@ -1,0 +1,16 @@
+import styled from "styled-components"
+
+const DetailPage = () => {
+  return <S.Wrapper>{/* <PostHeader /> */}</S.Wrapper>
+}
+
+export default DetailPage
+
+const Wrapper = styled.div`
+  width: 100vw;
+  height: 100vh;
+`
+
+const S = {
+  Wrapper,
+}

--- a/src/pages/sign/components/form-header.tsx
+++ b/src/pages/sign/components/form-header.tsx
@@ -11,8 +11,6 @@ const Title = styled.div`
   color: ${({ theme }) => theme.COLORS.primary["pink"]};
   font-size: 60px;
   ${flexCenter};
-  padding: 200px 0px;
-  font-weight: ${({ theme }) => theme.FONT_WEIGHT.thin};
 `
 
 const S = {

--- a/src/pages/sign/components/form-header.tsx
+++ b/src/pages/sign/components/form-header.tsx
@@ -1,0 +1,20 @@
+import { flexCenter } from "@/styles/common.style"
+import styled from "styled-components"
+
+const FormHeader = () => {
+  return <S.Title>POSTMOBISM</S.Title>
+}
+
+export default FormHeader
+
+const Title = styled.div`
+  color: ${({ theme }) => theme.COLORS.primary["pink"]};
+  font-size: 60px;
+  ${flexCenter};
+  padding: 200px 0px;
+  font-weight: ${({ theme }) => theme.FONT_WEIGHT.thin};
+`
+
+const S = {
+  Title,
+}

--- a/src/pages/sign/in-form.tsx
+++ b/src/pages/sign/in-form.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components"
 import FormHeader from "./components/form-header"
-import { flexCenter } from "@/styles/common.style"
+import { ViewPortSize, flexCenter } from "@/styles/common.style"
 import MMZinput from "@/components/mmz-input"
 import { SignInArr } from "@/consts/form"
 import MMZbutton from "@/components/mmz-button"
@@ -9,14 +9,14 @@ const SignIn = () => {
   return (
     <S.Wrapper>
       <FormHeader />
-      <S.Form>
-        {SignInArr.map(el => {
-          const { id, label, type, placeholder } = el
+      <S.FormContent>
+        {SignInArr.map(input => {
+          const { id, label, type, placeholder } = input
 
           return <MMZinput key={id} id={id} label={label} type={type} placeholder={placeholder} usage={"signForm"} />
         })}
         <MMZbutton usage={"SignForm"} type="submit" label={"sign in"} />
-      </S.Form>
+      </S.FormContent>
     </S.Wrapper>
   )
 }
@@ -24,20 +24,24 @@ const SignIn = () => {
 export default SignIn
 
 const Wrapper = styled.div`
-  width: 100vw;
-  height: 100vh;
+  ${ViewPortSize}
+  position: relative;
+  ${flexCenter}
+  flex-direction: column;
 `
 
-const Form = styled.form`
+const FormContent = styled.form`
+  width: 100%;
+  height: 552px;
   ${flexCenter}
-  display: flex;
   flex-direction: column;
+  margin-top: 80px;
   & > button {
-    margin-top: 200px;
+    margin-top: 158px;
   }
 `
 
 const S = {
   Wrapper,
-  Form,
+  FormContent,
 }

--- a/src/pages/sign/in-form.tsx
+++ b/src/pages/sign/in-form.tsx
@@ -1,0 +1,43 @@
+import styled from "styled-components"
+import FormHeader from "./components/form-header"
+import { flexCenter } from "@/styles/common.style"
+import MMZinput from "@/components/mmz-input"
+import { SignInArr } from "@/consts/form"
+import MMZbutton from "@/components/mmz-button"
+
+const SignIn = () => {
+  return (
+    <S.Wrapper>
+      <FormHeader />
+      <S.Form>
+        {SignInArr.map(el => {
+          const { id, label, type, placeholder } = el
+
+          return <MMZinput key={id} id={id} label={label} type={type} placeholder={placeholder} usage={"signForm"} />
+        })}
+        <MMZbutton usage={"SignForm"} type="submit" label={"sign in"} />
+      </S.Form>
+    </S.Wrapper>
+  )
+}
+
+export default SignIn
+
+const Wrapper = styled.div`
+  width: 100vw;
+  height: 100vh;
+`
+
+const Form = styled.form`
+  ${flexCenter}
+  display: flex;
+  flex-direction: column;
+  & > button {
+    margin-top: 200px;
+  }
+`
+
+const S = {
+  Wrapper,
+  Form,
+}

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -1,10 +1,15 @@
+import DetailPage from "@/pages/detail/detail.index"
 import SignIn from "@/pages/sign/in-form"
 import { createBrowserRouter } from "react-router-dom"
 
 const router = createBrowserRouter([
   {
-    path: "/",
+    path: "/signIn",
     element: <SignIn />,
+  },
+  {
+    path: "/detail",
+    element: <DetailPage />,
   },
 ])
 

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -1,5 +1,11 @@
+import SignIn from "@/pages/sign/in-form"
 import { createBrowserRouter } from "react-router-dom"
 
-const router = createBrowserRouter([])
+const router = createBrowserRouter([
+  {
+    path: "/",
+    element: <SignIn />,
+  },
+])
 
 export default router

--- a/src/styles/common.style.ts
+++ b/src/styles/common.style.ts
@@ -14,3 +14,33 @@ export const flexJustifyCenter = css`
   display: flex;
   justify-content: center;
 `
+
+// align : position
+export const PositionCenter = css`
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: translate(-50%, -50%);
+`
+export const PositionXCenter = css`
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+`
+export const PositionYCenter = css`
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+`
+
+// wrapper size
+export const ViewPortSize = css`
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
+`
+export const OutletSize = css`
+  width: 100vw;
+  height: calc(100vh - 150px);
+  overflow: hidden;
+`

--- a/src/styles/theme.style.ts
+++ b/src/styles/theme.style.ts
@@ -26,7 +26,7 @@ const FONT_SIZE = {
 }
 
 const FONT_WEIGHT = {
-  thin: 400,
+  thin: 100,
   regular: 500,
   bold: 700,
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"],
+  "include": ["src", "src/custom.d.ts"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
## 개요

- sign-in form 퍼블리싱 완료했습니다
- 적용 후 공용 input 에 필요한 속성들 추가하였습니다!

## PR 유형

어떤 변경 사항이 있나요?

-   [ ] 🟢 feat : 새로운 기능 추가
-   [ ] 🔴 Remove : 파일이나 폴더를 삭제하는 작업만 수행한 경우
-   [ ] 🔥 HOTFIX : 급하게 치명적인 버그를 고쳐야하는 경우
-   [ ] 🐞 fix : 버그수정
-   [x] 🎁 style : CSS 등 사용자 UI 디자인 변경
-   [ ] 💬 Comment : 필요한 주석 추가 및 변경
-   [ ] 💡 refactor : 기능, 코드 개선
-   [ ] 🔖 Rename : 파일 혹은 폴더명을 수정하거나 옮기는 작업만인 경우
-   [ ] 📂 docs : 문서 수정


## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

-   [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
-   [x] 직접 만든 함수가 있다면 이에 대한 설명을 추가했습니다. (ex. JS DOCS)
-   [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)


## PR details

📂 consts > form.ts 에 sign-in 에 들어갈 요소들을 map돌리기 위해 SignInArr 생성했습니다

<img width="772" alt="스크린샷 2024-02-06 오후 10 24 50" src="https://github.com/mobi-MIMIZ/PostMobism/assets/134191815/acb429fa-214a-4e7e-a1d2-47873a665d22">

구조 분해 할당하여 el의 속성들을 추출하여 이렇게 사용하고 있습니다

<img width="1104" alt="스크린샷 2024-02-06 오후 10 26 39" src="https://github.com/mobi-MIMIZ/PostMobism/assets/134191815/b57c4554-681e-4025-bbec-f8810ce4f12c">


------

Sign in과 up에서 모두 공용적으로 쓰일 거 같아서  📂sign  > components > form-header.tsx 로 분리했습니다.


1920x1052 기준으로 퍼블리싱된 Sign in Form입니다
(현재 폰트 미적용으로 figma와 조금 차이가 있을 수 있습니다.)

<img width="1680" alt="스크린샷 2024-02-06 오후 10 19 37" src="https://github.com/mobi-MIMIZ/PostMobism/assets/134191815/62ee80c6-8d2e-4c5a-a546-4d8741bb9cf8">

hover시

<img width="1680" alt="스크린샷 2024-02-06 오후 10 19 44" src="https://github.com/mobi-MIMIZ/PostMobism/assets/134191815/a6852bbd-e6d7-40bf-b349-acf23d381ab2">







